### PR TITLE
added landing page for missing old docs redirect

### DIFF
--- a/redirected.md
+++ b/redirected.md
@@ -1,0 +1,15 @@
+# Oops, that page was not found! :-(
+
+You followed a link to old and stale documentation that
+was no longer accurate or maintained. To avoid misleading 
+you with incorrect information, we had to take the page 
+down. We are sorry for the inconvenince.
+
+We have reorganized our documentation and divided them into
+guides starting from initial installation and proceeding into
+more advanced administration and maintenance topics.
+
+#### [Please proceed to the new documentation index.](/)
+
+Again, apologies for the trouble. We hope that you find
+the new guides useful.


### PR DESCRIPTION
Since we're killing off www.gluster.org/documentation/ with a redirect, this is where you'll land if you follow an old link via google etc.